### PR TITLE
Avoid polling after market close

### DIFF
--- a/custom_components/yahoo_stocks/__init__.py
+++ b/custom_components/yahoo_stocks/__init__.py
@@ -107,6 +107,13 @@ class StocksCoordinator(DataUpdateCoordinator[dict]):
         if not self.symbols:
             return {}
 
+        now = datetime.now(ZoneInfo("America/New_York"))
+        market_open_now = _is_market_open(now)
+        market_open_recent = _is_market_open(now - timedelta(minutes=30))
+
+        if not market_open_now and not market_open_recent and self.data:
+            return self.data  # type: ignore[return-value]
+
         async def fetch_symbol(sym: str) -> tuple[str, dict | None]:
             url = YF_URL.format(
                 symbol=sym, include_prepost=str(self.include_prepost).lower()


### PR DESCRIPTION
## Summary
- Skip Yahoo Finance fetches when the market has been closed for 30+ minutes by returning cached data

## Testing
- `python -m py_compile custom_components/yahoo_stocks/__init__.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac506c9b60832ba504ce90d33d54dd